### PR TITLE
Fix concurrent callback calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,12 +27,17 @@ module.exports = function (opts, cb, errorHandler) {
     }
 
     function flush() {
-        var holdOn = true;
-        asyncDone(cb.bind(cb, array(batch)), function (err) {
+        holdOn = true;
+        var currentBatch = batch;
+        batch = [];
+        asyncDone(cb.bind(cb, array(currentBatch)), function (err) {
             holdOn = false;
             if (err && typeof errorHandler === 'function') { errorHandler(err); }
+
+            if (batch.length) {
+                setupFlushTimeout();
+            }
         });
-        batch = [];
     }
 
     return function (event) {


### PR DESCRIPTION
Currently, gulp-batch will call the callback more than once concurrently if it gets an event while running the callback.  This is because the module-level `holdOn` variable is _not_ correctly set to true (the `var holdOn = ...` should just be `holdOn = ...`)!

Only removing the extraneous `var` would cause gulp-batch to completely ignore events while the callback is running, which is undesirable.  This patch stores events that occur during the callback, and - if any occurred - waits for the timeout interval after the callback ends and flushes them.
